### PR TITLE
ENH: Add desktop file

### DIFF
--- a/VideoRecStation/VideoRecStation.desktop
+++ b/VideoRecStation/VideoRecStation.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Version=1.0
+Name=VideoRecStation
+Comment=Record Video during MEG experiments
+Exec=/usr/local/bin/VideoRecStation
+Terminal=false
+Type=Application
+Icon=applications-science
+Categories=Science;Application;
+Name[en_US]=VideoRecStation


### PR DESCRIPTION
Instructions on the wiki could be updated to saying something like:

To facilitate launching the application, consider doing:

``` Bash
$ sudo ln -s ~/VideoMEG/VideoRecStation/Release/VideoRecStation /usr/local/bin/VideoRecStation
$ cp ~/VideoMEG/VideoRecStation/VideoRecStation.desktop ~/.local/share/applications
```

This will enable both command-line launching, and add the application to the Science section.

At some point the icon could be upgraded to something less generic, too.
