### PR TITLE
ENH: Dummy mode and window setting saving

### DIFF
--- a/VideoRecStation/src/common.h
+++ b/VideoRecStation/src/common.h
@@ -23,6 +23,7 @@
 // Camera configuration
 #define VIDEO_HEIGHT     	480
 #define VIDEO_WIDTH      	640
+#define MAX_CAMERAS         2
 
 // Audio configuration
 #define AUDIO_FORMAT		SND_PCM_FORMAT_S16_LE	// from <alsa/asoundlib.h>

--- a/VideoRecStation/src/filewriter.cpp
+++ b/VideoRecStation/src/filewriter.cpp
@@ -21,6 +21,7 @@
 #include <fstream>
 #include <stdlib.h>
 #include <stdio.h>
+#include <sys/stat.h>
 
 #include "filewriter.h"
 
@@ -122,6 +123,10 @@ void FileWriter::stoppableRun()
 			if (prevIsRec)
 			{
 				outData.close();
+                if (chmod(nameBuf, S_IRUSR | S_IRGRP | S_IROTH))
+                {
+                    cerr << "Could net set file read-only";
+                }
 			}
 		}
 
@@ -132,7 +137,11 @@ void FileWriter::stoppableRun()
 			if(prevIsRec)
 			{
 				outData.close();
-			}
+                if (chmod(nameBuf, S_IRUSR | S_IRGRP | S_IROTH))
+                {
+                    cerr << "Could net set file read-only";
+                }
+            }
 			return;
 		}
 	}

--- a/VideoRecStation/src/maindialog.cpp
+++ b/VideoRecStation/src/maindialog.cpp
@@ -129,7 +129,7 @@ void MainDialog::onStopRec()
 
 void MainDialog::setupVideoDialog(unsigned int idx)
 {
-    videoDialogs[idx] = new VideoDialog(cameras[idx], 2);
+    videoDialogs[idx] = new VideoDialog(cameras[idx], idx);
     if(settings.videoRects[idx].isValid())
         videoDialogs[idx]->setGeometry(settings.videoRects[idx]);
     videoDialogs[idx]->findChild<QSlider*>("shutterSlider")->setValue(settings.videoShutters[idx]);

--- a/VideoRecStation/src/maindialog.h
+++ b/VideoRecStation/src/maindialog.h
@@ -42,6 +42,7 @@ class MainDialog : public QMainWindow
 public:
     MainDialog(QWidget *parent = 0);
     ~MainDialog();
+    Settings 			settings;
 
 public slots:
     void onStartRec();
@@ -53,13 +54,13 @@ public slots:
 
 private:
     void initVideo();
+    void setupVideoDialog(unsigned int);
+    void cleanVideoDialog(unsigned int);
 
     Ui::MainDialogClass ui;
 
-    dc1394camera_t*		camera1;
-    dc1394camera_t*		camera2;
-	VideoDialog*		videoDialog1;
-	VideoDialog*		videoDialog2;
+    dc1394camera_t*		cameras[MAX_CAMERAS];
+    VideoDialog*		videoDialogs[MAX_CAMERAS];
 
     MicrophoneThread*	microphoneThread;
     CycDataBuffer*		cycAudioBuf;
@@ -72,7 +73,6 @@ private:
 	int					volIndNext;
 	SpeakerThread*		speakerThread;
 	NonBlockingBuffer*	speakerBuffer;
-	Settings 			settings;
 };
 
 #endif // MAINDIALOG_H

--- a/VideoRecStation/src/settings.h
+++ b/VideoRecStation/src/settings.h
@@ -20,6 +20,9 @@
 #ifndef SETTINGS_H_
 #define SETTINGS_H_
 
+#include <QRect>
+#include <common.h>
+
 //! Application-wide settings preserved across multiple invocations.
 /*!
  * This class contains application-wide settings read from disc. To read the
@@ -36,6 +39,7 @@ class Settings {
 	// TODO: implement singleton pattern?
 public:
 	Settings();
+    ~Settings();
 
 	// video
 	int				jpgQuality;
@@ -46,12 +50,19 @@ public:
 	unsigned int	framesPerPeriod;
 	unsigned int	nPeriods;
 	unsigned int	spkBufSz;
-	char			inpAudioDev[500];
-	char			outAudioDev[500];
+    char			inpAudioDev[500];
+    char			outAudioDev[500];
 	bool			useFeedback;
+    QRect           controllerRect;
+    QRect           videoRects[MAX_CAMERAS];
+    unsigned int    videoShutters[MAX_CAMERAS];
+    unsigned int    videoGains[MAX_CAMERAS];
+    unsigned int    videoUVs[MAX_CAMERAS];
+    unsigned int    videoVRs[MAX_CAMERAS];
 
 	// misc
-	char			storagePath[500];
+    char			storagePath[500];
+    bool            dummyMode;
 };
 
 #endif /* SETTINGS_H_ */

--- a/VideoRecStation/src/speakerthread.cpp
+++ b/VideoRecStation/src/speakerthread.cpp
@@ -116,14 +116,14 @@ void SpeakerThread::stoppableRun()
 	    if (rc == -EPIPE)
 	    {
 	    	/* EPIPE means underrun */
-			cerr << "underrun occurred" << endl;
+            cerr << "underrun occurred" << endl;
 	    	snd_pcm_prepare(sndHandle);
 	    }
 	    else if (rc < 0)
 	    {
 	    	cerr << "error from writei: " << snd_strerror(rc) << endl;
 	    }
-	    else if (rc != settings.framesPerPeriod)
+        else if (rc != (int)settings.framesPerPeriod)
 	    {
 	    	cerr << "short write, write " << rc << " frames" << endl;
 	    }

--- a/VideoRecStation/src/videodialog.cpp
+++ b/VideoRecStation/src/videodialog.cpp
@@ -26,16 +26,16 @@
 
 using namespace std;
 
-VideoDialog::VideoDialog(dc1394camera_t* _camera, int _cameraId, QWidget *parent)
+VideoDialog::VideoDialog(dc1394camera_t* _camera, int _cameraIdx, QWidget *parent)
     : QDialog(parent)
 {
 	char		winCaption[500];
     Settings	settings;
-    cameraId = _cameraId;
+    cameraIdx = _cameraIdx;
 
 	ui.setupUi(this);
 	setWindowFlags(Qt::Window | Qt::CustomizeWindowHint | Qt::WindowTitleHint| Qt::WindowSystemMenuHint | Qt::WindowMinMaxButtonsHint);
-    sprintf(winCaption, "Camera %i", cameraId);
+    sprintf(winCaption, "Camera %i", cameraIdx + 1);
 	setWindowTitle(winCaption);
 	camera = _camera;
 
@@ -43,7 +43,7 @@ VideoDialog::VideoDialog(dc1394camera_t* _camera, int _cameraId, QWidget *parent
 	cycVideoBufRaw = new CycDataBuffer(CIRC_VIDEO_BUFF_SZ);
 	cycVideoBufJpeg = new CycDataBuffer(CIRC_VIDEO_BUFF_SZ);
     cameraThread = new CameraThread(camera, cycVideoBufRaw, settings.color);
-    videoFileWriter = new VideoFileWriter(cycVideoBufJpeg, settings.storagePath, cameraId);
+    videoFileWriter = new VideoFileWriter(cycVideoBufJpeg, settings.storagePath, cameraIdx + 1);
 	videoCompressorThread = new VideoCompressorThread(cycVideoBufRaw, cycVideoBufJpeg, settings.color, settings.jpgQuality);
 
     QObject::connect(cycVideoBufJpeg, SIGNAL(chunkReady(unsigned char*)), ui.videoWidget, SLOT(onDrawFrame(unsigned char*)));
@@ -51,19 +51,19 @@ VideoDialog::VideoDialog(dc1394camera_t* _camera, int _cameraId, QWidget *parent
 	// Setup gain/shutter sliders
     ui.shutterSlider->setMinimum(SHUTTER_MIN_VAL);
     ui.shutterSlider->setMaximum(SHUTTER_MAX_VAL);
-    ui.shutterSlider->setValue(settings.videoShutters[cameraId-1]);
+    ui.shutterSlider->setValue(settings.videoShutters[cameraIdx]);
 
     ui.gainSlider->setMinimum(GAIN_MIN_VAL);
     ui.gainSlider->setMaximum(GAIN_MAX_VAL);
-    ui.gainSlider->setValue(settings.videoGains[cameraId-1]);
+    ui.gainSlider->setValue(settings.videoGains[cameraIdx]);
 
     ui.uvSlider->setMinimum(UV_MIN_VAL);
     ui.uvSlider->setMaximum(UV_MAX_VAL);
-    ui.uvSlider->setValue(settings.videoUVs[cameraId-1]);
+    ui.uvSlider->setValue(settings.videoUVs[cameraIdx]);
 
     ui.vrSlider->setMinimum(VR_MIN_VAL);
     ui.vrSlider->setMaximum(VR_MAX_VAL);
-    ui.vrSlider->setValue(settings.videoVRs[cameraId-1]);
+    ui.vrSlider->setValue(settings.videoVRs[cameraIdx]);
 
     ui.uvSlider->setEnabled(settings.color);
     ui.vrSlider->setEnabled(settings.color);
@@ -104,7 +104,7 @@ void VideoDialog::onShutterChanged(int _newVal)
 	dc1394error_t	err;
 
     Settings settings;
-    settings.videoShutters[cameraId-1] = _newVal;
+    settings.videoShutters[cameraIdx] = _newVal;
     if (!cameraThread || !camera)
 	{
 		return;
@@ -125,7 +125,7 @@ void VideoDialog::onGainChanged(int _newVal)
 	dc1394error_t	err;
 
     Settings settings;
-    settings.videoGains[cameraId-1] = _newVal;
+    settings.videoGains[cameraIdx] = _newVal;
     if (!cameraThread || !camera)
 	{
 		return;

--- a/VideoRecStation/src/videodialog.cpp
+++ b/VideoRecStation/src/videodialog.cpp
@@ -30,11 +30,12 @@ VideoDialog::VideoDialog(dc1394camera_t* _camera, int _cameraId, QWidget *parent
     : QDialog(parent)
 {
 	char		winCaption[500];
-	Settings	settings;
+    Settings	settings;
+    cameraId = _cameraId;
 
 	ui.setupUi(this);
 	setWindowFlags(Qt::Window | Qt::CustomizeWindowHint | Qt::WindowTitleHint| Qt::WindowSystemMenuHint | Qt::WindowMinMaxButtonsHint);
-	sprintf(winCaption, "Camera %i", _cameraId);
+    sprintf(winCaption, "Camera %i", cameraId);
 	setWindowTitle(winCaption);
 	camera = _camera;
 
@@ -42,7 +43,7 @@ VideoDialog::VideoDialog(dc1394camera_t* _camera, int _cameraId, QWidget *parent
 	cycVideoBufRaw = new CycDataBuffer(CIRC_VIDEO_BUFF_SZ);
 	cycVideoBufJpeg = new CycDataBuffer(CIRC_VIDEO_BUFF_SZ);
     cameraThread = new CameraThread(camera, cycVideoBufRaw, settings.color);
-	videoFileWriter = new VideoFileWriter(cycVideoBufJpeg, settings.storagePath, _cameraId);
+    videoFileWriter = new VideoFileWriter(cycVideoBufJpeg, settings.storagePath, cameraId);
 	videoCompressorThread = new VideoCompressorThread(cycVideoBufRaw, cycVideoBufJpeg, settings.color, settings.jpgQuality);
 
     QObject::connect(cycVideoBufJpeg, SIGNAL(chunkReady(unsigned char*)), ui.videoWidget, SLOT(onDrawFrame(unsigned char*)));
@@ -50,18 +51,22 @@ VideoDialog::VideoDialog(dc1394camera_t* _camera, int _cameraId, QWidget *parent
 	// Setup gain/shutter sliders
     ui.shutterSlider->setMinimum(SHUTTER_MIN_VAL);
     ui.shutterSlider->setMaximum(SHUTTER_MAX_VAL);
+    ui.shutterSlider->setValue(settings.videoShutters[cameraId-1]);
 
     ui.gainSlider->setMinimum(GAIN_MIN_VAL);
     ui.gainSlider->setMaximum(GAIN_MAX_VAL);
+    ui.gainSlider->setValue(settings.videoGains[cameraId-1]);
 
     ui.uvSlider->setMinimum(UV_MIN_VAL);
     ui.uvSlider->setMaximum(UV_MAX_VAL);
-    ui.uvSlider->setEnabled(settings.color);
+    ui.uvSlider->setValue(settings.videoUVs[cameraId-1]);
 
     ui.vrSlider->setMinimum(VR_MIN_VAL);
     ui.vrSlider->setMaximum(VR_MAX_VAL);
-    ui.vrSlider->setEnabled(settings.color);
+    ui.vrSlider->setValue(settings.videoVRs[cameraId-1]);
 
+    ui.uvSlider->setEnabled(settings.color);
+    ui.vrSlider->setEnabled(settings.color);
     ui.uvLabel->setEnabled(settings.color);
     ui.vrLabel->setEnabled(settings.color);
     ui.wbLabel->setEnabled(settings.color);
@@ -75,7 +80,7 @@ VideoDialog::VideoDialog(dc1394camera_t* _camera, int _cameraId, QWidget *parent
 
 VideoDialog::~VideoDialog()
 {
-	delete cycVideoBufRaw;
+    delete cycVideoBufRaw;
 	delete cycVideoBufJpeg;
 	delete cameraThread;
 	delete videoFileWriter;
@@ -98,7 +103,9 @@ void VideoDialog::onShutterChanged(int _newVal)
 {
 	dc1394error_t	err;
 
-	if (!cameraThread)
+    Settings settings;
+    settings.videoShutters[cameraId-1] = _newVal;
+    if (!cameraThread || !camera)
 	{
 		return;
 	}
@@ -117,7 +124,9 @@ void VideoDialog::onGainChanged(int _newVal)
 {
 	dc1394error_t	err;
 
-	if (!cameraThread)
+    Settings settings;
+    settings.videoGains[cameraId-1] = _newVal;
+    if (!cameraThread || !camera)
 	{
 		return;
 	}
@@ -136,7 +145,7 @@ void VideoDialog::onUVChanged(int _newVal)
 {
 	dc1394error_t	err;
 
-	if (!cameraThread)
+    if (!cameraThread || !camera)
 	{
 		return;
 	}
@@ -156,7 +165,7 @@ void VideoDialog::onVRChanged(int _newVal)
 {
 	dc1394error_t	err;
 
-	if (!cameraThread)
+    if (!cameraThread || !camera)
 	{
 		return;
 	}

--- a/VideoRecStation/src/videodialog.h
+++ b/VideoRecStation/src/videodialog.h
@@ -55,7 +55,7 @@ public slots:
 private:
     Ui::VideoDialogClass ui;
 
-    unsigned int            cameraId;
+    unsigned int            cameraIdx;
     dc1394camera_t*			camera;
     CameraThread*       	cameraThread;
     CycDataBuffer*			cycVideoBufRaw;

--- a/VideoRecStation/src/videodialog.h
+++ b/VideoRecStation/src/videodialog.h
@@ -55,6 +55,7 @@ public slots:
 private:
     Ui::VideoDialogClass ui;
 
+    unsigned int            cameraId;
     dc1394camera_t*			camera;
     CameraThread*       	cameraThread;
     CycDataBuffer*			cycVideoBufRaw;


### PR DESCRIPTION
This bundle of source code changes:

1. Enables a "dummy" mode in the config file so that development can be done off-site.

2. Adds persistence of window geometry.

3. Moves toward abstracting the (maximum) number of cameras, and the use of those cameras. Support isn't complete, but at some point if 3 cameras are needed, the changes will be helpful.

4. Sets output files as read-only.

Feel free to nitpick on style, and/or make substantive code content comments. This is my first big PR into the C code, so it would be good to lay the groundwork appropriately for other contributions.