### PR TITLE
ENH: Add audio-only export

### DIFF
--- a/PyVideoMEG/bin/pvm_export_audio.py
+++ b/PyVideoMEG/bin/pvm_export_audio.py
@@ -1,0 +1,47 @@
+#!/usr/bin/python -tt
+
+"""
+Export an audio file to a standard audio format. Requires scipy.
+
+Usage: pvm_export_audio audio_file_name
+
+---------------------------------------------------------------------------
+Author: Andrey Zhdanov
+Copyright (C) 2014 BioMag Laboratory, Helsinki University Central Hospital
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, version 3.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+import sys
+from scipy.io import wavfile
+import numpy as np
+from os import path as op
+
+import pyvideomeg
+
+for aud_file in sys.argv[1:]:
+    if not op.isfile(aud_file):
+        raise IOError('file not found: %s' % aud_file)
+    if op.splitext(aud_file)[1] != '.aud':
+        raise ValueError('unknown extension "%s"' % op.splitext(aud_file)[1])
+    out_file = op.splitext(aud_file)[0] + '.wav'
+    if op.isfile(out_file):
+        print('Skipping, output file exists: %s' % out_file)
+        continue
+    print('Creating file: %s' % out_file)
+    sys.stdout.flush()
+    aud_file = pyvideomeg.AudioData(aud_file)
+    rate = aud_file.srate
+    n_ch = aud_file.nchan
+    aud_file = np.frombuffer(aud_file.raw_audio, '<i2').reshape(-1, n_ch)
+    wavfile.write(out_file, rate, aud_file)

--- a/PyVideoMEG/setup.py
+++ b/PyVideoMEG/setup.py
@@ -64,6 +64,7 @@ if __name__ == '__main__':
             op.join('bin', 'pvm_data_converter.py'),
             op.join('bin', 'pvm_data_converter0_1.py'),
             op.join('bin', 'pvm_export.py'),
+            op.join('bin', 'pvm_export_audio.py'),
             op.join('bin', 'pvm_export_dragdrop.py'),
             op.join('bin', 'pvm_repack_audio.py'),
             op.join('bin', 'pvm_show_info.py'),


### PR DESCRIPTION
In some experiments we only record audio, and we need a way to convert it to a human-usable format.