### PR TITLE
keep the timestamps and IDs as uint64

### DIFF
--- a/matlab/load_audio0123.m
+++ b/matlab/load_audio0123.m
@@ -63,8 +63,8 @@ function [ts, ids, offset, data, srate, site_id, is_sender] = load_audio0123(fil
     numof_chunks = (dt_end - dt_start) / (attrib_sz + buflen);
     
     % allocate the memory
-    ts = zeros(numof_chunks, 1);
-    ids = zeros(numof_chunks, 1);
+    ts = zeros(numof_chunks, 1, 'uint64');
+    ids = zeros(numof_chunks, 1, 'uint64');
     data = zeros(frames_per_buf*nchans, numof_chunks);
     
     % compute offset
@@ -118,12 +118,12 @@ end
 
 function [t, id, blen] = read_attrib(h, ver)
     assert(ver==0 | ver==1 | ver==2 | ver==3);
-    t = fread(h, 1, 'uint64');
+    t = fread(h, 1, 'uint64=>uint64');
         
     if(ver==2 | ver==3)
-        id = fread(h, 1, 'uint64');
+        id = fread(h, 1, 'uint64=>uint64');
     else
-        id = 0;
+        id = -1;
     end
 
     blen = fread(h, 1, 'uint32');

--- a/matlab/load_video123.m
+++ b/matlab/load_video123.m
@@ -50,16 +50,16 @@ function [ts, ids, site_id, is_sender, frame_sizes, frame_ptrs] = load_video123(
     frame_ptrs = [];
     
     while(ftell(inpf) < inp_sz)
-        tstamp = fread(inpf, 1, 'uint64');
+        tstamp = fread(inpf, 1, 'uint64=>uint64');
         if(ver > 1)
-            chunk_id = fread(inpf, 1, 'uint64');
+            chunk_id = fread(inpf, 1, 'uint64=>uint64');
         else
             chunk_id = -1;
         end
                 
         chunk_sz = fread(inpf, 1, 'uint32');
         frame_ptrs = [frame_ptrs, ftell(inpf)];
-        chunk = fread(inpf, chunk_sz, 'uchar');
+        chunk = fread(inpf, chunk_sz, 'uchar=>uchar');
         
         ts = [ts, tstamp];
         ids = [ids, chunk_id];


### PR DESCRIPTION
Hi Andrey,

I don't know whether you recall me, but we met at ISACM in Helsinki earlier this year. I just started working on VideoMEG data recorded at NatMEG (recorded by Daniel and Fanny). I want to provide a way of using NatMEG VideoMEG data in FieldTrip and might want to implement the setup in Nijmegen as well. To make the integration with FieldTrip a bit smoother, I would like to contribute some suggestions to your code. 

This is a small change to keep the timestamps and the IDs in uint64 format, rather than converting them in double. The numerical precision in double is limited and rounding-off errors can happen.

Thanks for the VideoMEG system and sharing this code.
Robert 

 